### PR TITLE
Ignore go generated files, strip binary, statically compile

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func obfuscate(keepTests, outGopath bool, encKey, pkgName, outPath string) bool 
 	if !outGopath {
 		ctx := build.Default
 		newPkg := encryptComponents(pkgName, enc)
-		cmd := exec.Command("go", "build", "-o", outPath, newPkg)
+		cmd := exec.Command("go", "build", `-ldflags=-s -w -extldflags "-static"`, "-o", outPath, newPkg)
 		cmd.Env = []string{"GOROOT=" + ctx.GOROOT, "GOARCH=" + ctx.GOARCH,
 			"GOOS=" + ctx.GOOS, "GOPATH=" + newGopath, "PATH=" + os.Getenv("PATH")}
 		cmd.Stdout = os.Stdout

--- a/symbols.go
+++ b/symbols.go
@@ -262,7 +262,7 @@ func containsCGO(dir string) bool {
 }
 
 // containsIgnoreConstraint checks if the file contains an
-// "ignore" build constraint.
+// "ignore" build constraint or "DO NOT EDIT!" generation marker.
 func containsIgnoreConstraint(path string) bool {
 	set := token.NewFileSet()
 	file, err := parser.ParseFile(set, path, nil, parser.ParseComments)
@@ -271,8 +271,10 @@ func containsIgnoreConstraint(path string) bool {
 	}
 	packagePos := file.Package
 	for _, comment := range file.Comments {
-		if strings.TrimRight(comment.Text(), "\n\r") == "+build ignore" &&
-			comment.Pos() < packagePos {
+		commentStr := strings.TrimRight(comment.Text(), "\n\r")
+		if comment.Pos() < packagePos &&
+			(commentStr == "+build ignore" ||
+				strings.Contains(commentStr, "DO NOT EDIT")) {
 			return true
 		}
 	}


### PR DESCRIPTION
Hi @unixpickle, thanks for making this tool 👍 

I forked for my use case and was wondering if you wanted any of these changes upstream?

I needed to:
- Ignore file generated by `go generate`
- Strip the binary
- Statically compile the binary