### PR TITLE
Improve performance and cleanup code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore binary
+/gobfuscate
+*.exe

--- a/README.md
+++ b/README.md
@@ -4,25 +4,55 @@ When you compile a Go binary, it contains a lot of information about your source
 
 With gobfuscate, you can compile a Go binary from obfuscated source code. This makes a lot of information difficult or impossible to decipher from the binary.
 
+# How to use
+```
+go get -u github.com/unixpickle/gobfuscate
+gobfuscate [flags] pkg_name out_path
+```
+`pkg_name` is the path relative from your $GOPATH/src to the package to obfuscate (typically something like domain.tld/user/repo)
+`out_path` is the path where the binary will be written to
+
+### Flags
+```
+Usage: gobfuscate [flags] pkg_name out_path
+  -keeptests
+    	keep _test.go files
+  -noencrypt
+    	no encrypted package name for go build command (works when main package has CGO code)
+  -nostatic
+    	do not statically link
+  -outdir
+    	output a full GOPATH
+  -padding string
+    	use a custom padding for hashing sensitive information (otherwise a random padding will be used)
+  -tags string
+    	tags are passed to the go compiler
+  -verbose
+    	verbose mode
+  -winhide
+    	hide windows GUI
+```
+
+
 # What it does
 
 Currently, gobfuscate manipulates package names, global variable and function names, type names, method names, and strings.
 
 ## Package name obfuscation
 
-When gobfuscate builds your program, it constructs a copy of a subset of your GOPATH. It then refactors this GOPATH by encrypting package names and paths. As a result, a package like "github.com/unixpickle/deleteme" becomes something like "jiikegpkifenppiphdhi/igijfdokiaecdkihheha/jhiofoppieegdaif". This helps get rid of things like Github usernames from the executable.
+When gobfuscate builds your program, it constructs a copy of a subset of your GOPATH. It then refactors this GOPATH by hashing package names and paths. As a result, a package like "github.com/unixpickle/deleteme" becomes something like "jiikegpkifenppiphdhi/igijfdokiaecdkihheha/jhiofoppieegdaif". This helps get rid of things like Github usernames from the executable.
 
 **Limitation:** currently, packages which use CGO cannot be renamed. I suspect this is due to a bug in Go's refactoring API.
 
 ## Global names
 
-Gobfuscate encrypts the names of global vars, consts, and funcs. It also encrypts the names of any newly-defined types.
+Gobfuscate hashes the names of global vars, consts, and funcs. It also hashes the names of any newly-defined types.
 
 Due to restrictions in the refactoring API, this does not work for packages which contain assembly files or use CGO. It also does not work for names which appear multiple times because of build constraints.
 
 ## Struct methods
 
-Gobfuscate encrypts the names of most struct methods. However, it does not rename methods whose names match methods of any imported interfaces. This is mostly due to internal constraints from the refactoring engine. Theoretically, most interfaces could be obfuscated as well (except for those in the standard library).
+Gobfuscate hashes the names of most struct methods. However, it does not rename methods whose names match methods of any imported interfaces. This is mostly due to internal constraints from the refactoring engine. Theoretically, most interfaces could be obfuscated as well (except for those in the standard library).
 
 Due to restrictions in the refactoring API, this does not work for packages which contain assembly files or use CGO. It also does not work for names which appear multiple times because of build constraints.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ go get -u github.com/unixpickle/gobfuscate
 gobfuscate [flags] pkg_name out_path
 ```
 `pkg_name` is the path relative from your $GOPATH/src to the package to obfuscate (typically something like domain.tld/user/repo)
+
 `out_path` is the path where the binary will be written to
 
 ### Flags
@@ -38,25 +39,25 @@ Usage: gobfuscate [flags] pkg_name out_path
 
 Currently, gobfuscate manipulates package names, global variable and function names, type names, method names, and strings.
 
-## Package name obfuscation
+### Package name obfuscation
 
 When gobfuscate builds your program, it constructs a copy of a subset of your GOPATH. It then refactors this GOPATH by hashing package names and paths. As a result, a package like "github.com/unixpickle/deleteme" becomes something like "jiikegpkifenppiphdhi/igijfdokiaecdkihheha/jhiofoppieegdaif". This helps get rid of things like Github usernames from the executable.
 
 **Limitation:** currently, packages which use CGO cannot be renamed. I suspect this is due to a bug in Go's refactoring API.
 
-## Global names
+### Global names
 
 Gobfuscate hashes the names of global vars, consts, and funcs. It also hashes the names of any newly-defined types.
 
 Due to restrictions in the refactoring API, this does not work for packages which contain assembly files or use CGO. It also does not work for names which appear multiple times because of build constraints.
 
-## Struct methods
+### Struct methods
 
 Gobfuscate hashes the names of most struct methods. However, it does not rename methods whose names match methods of any imported interfaces. This is mostly due to internal constraints from the refactoring engine. Theoretically, most interfaces could be obfuscated as well (except for those in the standard library).
 
 Due to restrictions in the refactoring API, this does not work for packages which contain assembly files or use CGO. It also does not work for names which appear multiple times because of build constraints.
 
-## Strings
+### Strings
 
 Strings are obfuscated by replacing them with functions. A string will be turned into an expression like the following:
 

--- a/const_to_var.go
+++ b/const_to_var.go
@@ -18,7 +18,7 @@ func stringConstsToVar(path string) error {
 	}
 
 	set := token.NewFileSet()
-	file, err := parser.ParseFile(set, path, nil, 0)
+	file, err := parser.ParseFile(set, path, contents, 0)
 	if err != nil {
 		// If the file is invalid, we do nothing.
 		return nil

--- a/gopath_copy.go
+++ b/gopath_copy.go
@@ -67,7 +67,10 @@ func findDeps(packageName string, ctx *build.Context) (map[string]bool, error) {
 
 func copyDep(pkg *build.Package, newGopath string, keepTests bool) error {
 	newPath := filepath.Join(newGopath, "src", pkg.ImportPath)
-	createDir(newPath)
+	err := os.MkdirAll(newPath, 0755)
+	if err != nil {
+		return err
+	}
 
 	srcFiles := [][]string{
 		pkg.GoFiles,
@@ -124,23 +127,6 @@ func containsDep(gopath, dir string, deps map[string]bool) bool {
 		}
 	}
 	return false
-}
-
-func createDir(dir string) error {
-	if info, err := os.Stat(dir); err == nil {
-		if info.IsDir() {
-			return nil
-		} else {
-			return fmt.Errorf("file already exists: %s", dir)
-		}
-	}
-	if filepath.Dir(dir) != dir {
-		parent := filepath.Dir(dir)
-		if err := createDir(parent); err != nil {
-			return err
-		}
-	}
-	return os.Mkdir(dir, 0755)
 }
 
 func copyFile(src, dest string) error {

--- a/gopath_copy.go
+++ b/gopath_copy.go
@@ -38,14 +38,6 @@ func CopyGopath(packageName, newGopath string, keepTests bool) error {
 		}
 	}
 
-	if !keepTests {
-		ctx.GOPATH = newGopath
-		allDeps, err = findDeps(packageName, &ctx)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/gopath_copy.go
+++ b/gopath_copy.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"golang.org/x/tools/refactor/importgraph"
 )
@@ -45,10 +44,6 @@ func CopyGopath(packageName, newGopath string, keepTests bool) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if err := removeUnusedPkgs(newGopath, allDeps); err != nil {
-		return err
 	}
 
 	return nil
@@ -100,33 +95,6 @@ func copyDep(pkg *build.Package, newGopath string, keepTests bool) error {
 	}
 
 	return nil
-}
-
-func removeUnusedPkgs(gopath string, deps map[string]bool) error {
-	srcDir := filepath.Join(gopath, "src")
-	return filepath.Walk(srcDir, func(sub string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			return nil
-		}
-		if !containsDep(gopath, sub, deps) {
-			os.RemoveAll(sub)
-			return filepath.SkipDir
-		}
-		return nil
-	})
-}
-
-func containsDep(gopath, dir string, deps map[string]bool) bool {
-	for dep := range deps {
-		depDir := filepath.Clean(filepath.Join(gopath, "src", dep))
-		if strings.HasPrefix(depDir, filepath.Clean(dir)) {
-			return true
-		}
-	}
-	return false
 }
 
 func copyFile(src, dest string) error {

--- a/hash.go
+++ b/hash.go
@@ -8,14 +8,14 @@ import (
 
 const hashedSymbolSize = 10
 
-// A Padding is added to the input of a hash function
+// A NameHasher is added to the input of a hash function
 // to make it 'impossible' to find the input value
-type Padding []byte
+type NameHasher []byte
 
 // Hash hashes the padding + token.
 // The case of the first letter of the token is preserved.
-func (p Padding) Hash(token string) string {
-	hashArray := sha256.Sum256(append(p, []byte(token)...))
+func (n NameHasher) Hash(token string) string {
+	hashArray := sha256.Sum256(append(n, []byte(token)...))
 
 	hexStr := strings.ToLower(hex.EncodeToString(hashArray[:hashedSymbolSize]))
 	for i, x := range hexStr {

--- a/hash.go
+++ b/hash.go
@@ -8,15 +8,14 @@ import (
 
 const hashedSymbolSize = 10
 
-// An Encrypter encrypts textual tokens.
-type Encrypter struct {
-	Key string
-}
+// A Padding is added to the input of a hash function
+// to make it 'impossible' to find the input value
+type Padding []byte
 
-// Encrypt encrypts the token.
+// Hash hashes the padding + token.
 // The case of the first letter of the token is preserved.
-func (e *Encrypter) Encrypt(token string) string {
-	hashArray := sha256.Sum256([]byte(e.Key + token))
+func (p Padding) Hash(token string) string {
+	hashArray := sha256.Sum256(append(p, []byte(token)...))
 
 	hexStr := strings.ToLower(hex.EncodeToString(hashArray[:hashedSymbolSize]))
 	for i, x := range hexStr {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"go/build"
 	"io/ioutil"
 	"log"
-	"math/rand"
+	"crypto/rand"
 	"os"
 	"os/exec"
 	"strings"

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 // Command line arguments.
 var (
 	customPadding       string
+	tags                string
 	outputGopath        bool
 	keepTests           bool
 	winHide             bool
@@ -32,6 +33,7 @@ func main() {
 	flag.BoolVar(&preservePackageName, "noencrypt", false,
 		"no encrypted package name for go build command (works when main package has CGO code)")
 	flag.BoolVar(&verbose, "verbose", false, "verbose mode")
+	flag.StringVar(&tags, "tags", "", "tags are passed to the go compiler")
 
 	flag.Parse()
 
@@ -109,18 +111,20 @@ func obfuscate(pkgName, outPath string) bool {
 		newPkg = encryptComponents(pkgName, p)
 	}
 
-	ldflags := `-ldflags=-s -w`
+	ldflags := `-ldflags "-s -w`
 	if winHide {
 		ldflags += " -H=windowsgui"
 	}
 	if !noStaticLink {
-		ldflags += ` -extldflags "-static"`
+		ldflags += ` -extldflags '-static'`
 	}
+	ldflags += `"`
+	tagsFlag := `-tags "` + tags + `"`
 
 	goCache := newGopath + "/cache"
 	os.Mkdir(goCache, 0755)
 
-	arguments := []string{"build", ldflags, "-o", outPath, newPkg}
+	arguments := []string{"build", ldflags, tagsFlag, "-o", outPath, newPkg}
 	environment := []string{
 		"GOROOT=" + ctx.GOROOT,
 		"GOARCH=" + ctx.GOARCH,

--- a/pkg_names.go
+++ b/pkg_names.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/tools/refactor/rename"
 )
 
-func ObfuscatePackageNames(gopath string, p Padding) error {
+func ObfuscatePackageNames(gopath string, n NameHasher) error {
 	ctx := build.Default
 	ctx.GOPATH = gopath
 
@@ -37,7 +37,7 @@ func ObfuscatePackageNames(gopath string, p Padding) error {
 				continue
 			}
 			isMain := isMainPackage(dirPath)
-			encPath := encryptPackageName(dirPath, p)
+			encPath := encryptPackageName(dirPath, n)
 			srcPkg, err := filepath.Rel(srcDir, dirPath)
 			if err != nil {
 				return err
@@ -86,7 +86,7 @@ func scanLevel(dir string, depth int, res chan<- string, done <-chan struct{}) {
 	}
 }
 
-func encryptPackageName(dir string, p Padding) string {
+func encryptPackageName(dir string, p NameHasher) string {
 	subDir, base := filepath.Split(dir)
 	return filepath.Join(subDir, p.Hash(base))
 }

--- a/pkg_names.go
+++ b/pkg_names.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/tools/refactor/rename"
 )
 
-func ObfuscatePackageNames(gopath string, enc *Encrypter) error {
+func ObfuscatePackageNames(gopath string, p Padding) error {
 	ctx := build.Default
 	ctx.GOPATH = gopath
 
@@ -37,7 +37,7 @@ func ObfuscatePackageNames(gopath string, enc *Encrypter) error {
 				continue
 			}
 			isMain := isMainPackage(dirPath)
-			encPath := encryptPackageName(dirPath, enc)
+			encPath := encryptPackageName(dirPath, p)
 			srcPkg, err := filepath.Rel(srcDir, dirPath)
 			if err != nil {
 				return err
@@ -86,9 +86,9 @@ func scanLevel(dir string, depth int, res chan<- string, done <-chan struct{}) {
 	}
 }
 
-func encryptPackageName(dir string, enc *Encrypter) string {
+func encryptPackageName(dir string, p Padding) string {
 	subDir, base := filepath.Split(dir)
-	return filepath.Join(subDir, enc.Encrypt(base))
+	return filepath.Join(subDir, p.Hash(base))
 }
 
 func isMainPackage(dir string) bool {

--- a/pkg_names.go
+++ b/pkg_names.go
@@ -100,11 +100,11 @@ func isMainPackage(dir string) bool {
 		if isGoFile(item.Name()) {
 			path := filepath.Join(dir, item.Name())
 			set := token.NewFileSet()
-			file, err := parser.ParseFile(set, path, nil, 0)
+			contents, err := ioutil.ReadFile(path)
 			if err != nil {
 				return false
 			}
-			contents, err := ioutil.ReadFile(path)
+			file, err := parser.ParseFile(set, path, contents, 0)
 			if err != nil {
 				return false
 			}
@@ -128,12 +128,13 @@ func makeMainPackage(dir string) error {
 			continue
 		}
 		path := filepath.Join(dir, item.Name())
-		set := token.NewFileSet()
-		file, err := parser.ParseFile(set, path, nil, 0)
+		contents, err := ioutil.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		contents, err := ioutil.ReadFile(path)
+
+		set := token.NewFileSet()
+		file, err := parser.ParseFile(set, path, contents, 0)
 		if err != nil {
 			return err
 		}

--- a/pkg_names.go
+++ b/pkg_names.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/tools/refactor/rename"
 )
 
-const GoExtension = ".go"
-
 func ObfuscatePackageNames(gopath string, enc *Encrypter) error {
 	ctx := build.Default
 	ctx.GOPATH = gopath
@@ -99,7 +97,7 @@ func isMainPackage(dir string) bool {
 		return false
 	}
 	for _, item := range listing {
-		if filepath.Ext(item.Name()) == GoExtension {
+		if isGoFile(item.Name()) {
 			path := filepath.Join(dir, item.Name())
 			set := token.NewFileSet()
 			file, err := parser.ParseFile(set, path, nil, 0)
@@ -126,7 +124,7 @@ func makeMainPackage(dir string) error {
 		return err
 	}
 	for _, item := range listing {
-		if filepath.Ext(item.Name()) != GoExtension {
+		if !isGoFile(item.Name()) {
 			continue
 		}
 		path := filepath.Join(dir, item.Name())

--- a/strings.go
+++ b/strings.go
@@ -26,14 +26,15 @@ func ObfuscateStrings(gopath string) error {
 			return err
 		}
 
-		set := token.NewFileSet()
-		file, err := parser.ParseFile(set, path, nil, 0)
-		if err != nil {
-			return nil
-		}
 		contents, err := ioutil.ReadFile(path)
 		if err != nil {
 			return err
+		}
+
+		set := token.NewFileSet()
+		file, err := parser.ParseFile(set, path, contents, 0)
+		if err != nil {
+			return nil
 		}
 
 		obfuscator := &stringObfuscator{Contents: contents}

--- a/strings.go
+++ b/strings.go
@@ -19,7 +19,7 @@ func ObfuscateStrings(gopath string) error {
 		if err != nil {
 			return err
 		}
-		if filepath.Ext(path) != GoExtension || info.IsDir() {
+		if info.IsDir() || !isGoFile(path) {
 			return nil
 		}
 		if err := stringConstsToVar(path); err != nil {

--- a/symbols.go
+++ b/symbols.go
@@ -71,7 +71,7 @@ func topLevelRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
 		if info.IsDir() && containsUnsupportedCode(path) {
 			return filepath.SkipDir
 		}
-		if filepath.Ext(path) != GoExtension {
+		if !isGoFile(path) {
 			return nil
 		}
 		pkgPath, err := filepath.Rel(srcDir, filepath.Dir(path))
@@ -122,7 +122,7 @@ func methodRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
 		if info.IsDir() && containsUnsupportedCode(path) {
 			return filepath.SkipDir
 		}
-		if filepath.Ext(path) != GoExtension {
+		if !isGoFile(path) {
 			return nil
 		}
 		pkgPath, err := filepath.Rel(srcDir, filepath.Dir(path))
@@ -248,7 +248,7 @@ func containsCGO(dir string) bool {
 		return false
 	}
 	for _, item := range listing {
-		if filepath.Ext(item.Name()) == GoExtension {
+		if isGoFile(item.Name()) {
 			path := filepath.Join(dir, item.Name())
 			set := token.NewFileSet()
 			file, err := parser.ParseFile(set, path, nil, 0)
@@ -273,7 +273,7 @@ func removeDoNotEdit(dir string) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || filepath.Ext(path) != GoExtension {
+		if info.IsDir() || !isGoFile(path) {
 			return nil
 		}
 

--- a/symbols.go
+++ b/symbols.go
@@ -23,16 +23,16 @@ type symbolRenameReq struct {
 	NewName string
 }
 
-func ObfuscateSymbols(gopath string, enc *Encrypter) error {
+func ObfuscateSymbols(gopath string, p Padding) error {
 	removeDoNotEdit(gopath)
-	renames, err := topLevelRenames(gopath, enc)
+	renames, err := topLevelRenames(gopath, p)
 	if err != nil {
 		return fmt.Errorf("top-level renames: %s", err)
 	}
 	if err := runRenames(gopath, renames); err != nil {
 		return fmt.Errorf("top-level renaming: %s", err)
 	}
-	renames, err = methodRenames(gopath, enc)
+	renames, err = methodRenames(gopath, p)
 	if err != nil {
 		return fmt.Errorf("method renames: %s", err)
 	}
@@ -54,13 +54,13 @@ func runRenames(gopath string, renames []symbolRenameReq) error {
 	return nil
 }
 
-func topLevelRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
+func topLevelRenames(gopath string, p Padding) ([]symbolRenameReq, error) {
 	srcDir := filepath.Join(gopath, "src")
 	res := map[symbolRenameReq]int{}
 	addRes := func(pkgPath, name string) {
 		prefix := "\"" + pkgPath + "\"."
 		oldName := prefix + name
-		newName := enc.Encrypt(name)
+		newName := p.Hash(name)
 		res[symbolRenameReq{oldName, newName}]++
 	}
 	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
@@ -106,7 +106,7 @@ func topLevelRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
 	return singleRenames(res), err
 }
 
-func methodRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
+func methodRenames(gopath string, p Padding) ([]symbolRenameReq, error) {
 	exclude, err := interfaceMethods(gopath)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func methodRenames(gopath string, enc *Encrypter) ([]symbolRenameReq, error) {
 					continue
 				}
 				oldName := receiver + "." + d.Name.Name
-				newName := enc.Encrypt(d.Name.Name)
+				newName := p.Hash(d.Name.Name)
 				res[symbolRenameReq{oldName, newName}]++
 			}
 		}

--- a/symbols.go
+++ b/symbols.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +48,8 @@ func runRenames(gopath string, renames []symbolRenameReq) error {
 	ctx.GOPATH = gopath
 	for _, r := range renames {
 		if err := rename.Main(&ctx, "", r.OldName, r.NewName); err != nil {
-			return err
+			log.Println("Error running renames proceding...", err)
+			continue
 		}
 	}
 	return nil

--- a/util.go
+++ b/util.go
@@ -1,0 +1,7 @@
+package main
+
+import "path/filepath"
+
+func isGoFile(path string) bool {
+	return filepath.Ext(path) == ".go"
+}


### PR DESCRIPTION
Improved performance by fixing some instances where the same file was read more than once.

Fixes #20 by adding a continue.

Remove own createDir function for recursively creating directories and switch to os.MkdirAll.

Remove unnecessary check for files which would not be copied in the first place.

Move multiple Checks whether a file is a .go file to a function for better readability